### PR TITLE
Change the .feature file to use the third-person narrative

### DIFF
--- a/UpdraftUITests/Features/An array.feature
+++ b/UpdraftUITests/Features/An array.feature
@@ -1,12 +1,11 @@
 Feature: An array
 
-    Scenario: Appending to an array
-    Given I have an empty array
-    When I add 1 to the array
-    Then I should have 1 item in the array
+    Scenario: Append to an array
+    Given an empty array
+    When the number 1 is added to the array
+    Then the array has 1 items
 
-    Scenario: Filtering an array
-    Given I have an array with the numbers 1 through 5
-    When I filter the array for even numbers
-    Then I should have 2 items in the array
-
+    Scenario: Filter an array
+    Given an array with the numbers 1 through 5
+    When the array is filtered for even numbers
+    Then the array has 2 items

--- a/UpdraftUITests/UpdraftUITests.swift
+++ b/UpdraftUITests/UpdraftUITests.swift
@@ -15,31 +15,31 @@ class UpdraftUITests: XCTestCase {
         
         let featureFile = FeatureFile(name: "An array.feature")
         
-        featureFile.given("^I have an empty array$") { match in
+        featureFile.given("^an empty array$") { match in
             array = []
         }
         
-        featureFile.when("^I add (\\d) to the array$") { match in
-            let number = Int(match.groups[1])!
-            array.append(number)
+        featureFile.when("^the number 1 is added to the array$") { match in
+            array.append(1)
         }
         
-        featureFile.then("^I should have (\\d) items? in the array$") { match in
-            let count = Int(match.groups[1])!
-            XCTAssertEqual(array.count, count)
+        featureFile.then("^the array has (\\d) items$") { match in
+            let itemCount = Int(match.groups[1])!
+            XCTAssertEqual(array.count, itemCount)
         }
         
-        featureFile.given("^I have an array with the numbers (\\d) through (\\d)$") { match in
-            let start = match.groups[1]
-            let end = match.groups[2]
+        featureFile.given("^an array with the numbers (\\d) through (\\d)$") { match in
+            let start = Int(match.groups[1])!
+            let end = Int(match.groups[2])!
             
-            array = Array(Int(start)! ..< Int(end)!)
+            array = Array(start ..< end)
         }
         
-        featureFile.when("^I filter the array for even numbers$") { match in
+        featureFile.when("^the array is filtered for even numbers$") { match in
             array = array.filter { $0 % 2 == 0 }
         }
         
         featureFile.run()
     }
 }
+


### PR DESCRIPTION
> Third-person perspective is entirely generic and can expressively name any user or system component.  First-person semantically limits the expressive coverage of a step by forcing presumptions of who the speaker is. https://automationpanda.com/2017/01/18/should-gherkin-steps-use-first-person-or-third-person/